### PR TITLE
feat: register, register/done 페이지 search api 연동 완료 (#24)

### DIFF
--- a/src/app/(main)/register/done/page.tsx
+++ b/src/app/(main)/register/done/page.tsx
@@ -2,13 +2,18 @@
 
 import styled from 'styled-components';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { COLORS, TEXT_COLORS } from '@/constants/colors';
 import { FONTS } from '@/constants/font';
 import backIcon from '../../../../assets/icons/back-icon.png';
+import { getParticle } from '@/utils/postposition';
 
 export default function RegisterDonePage() {
     const router = useRouter();
+    const searchParams = useSearchParams();
+
+    const name = searchParams.get('name');
+    const img = searchParams.get('img');
 
     const handleBack = () => {
         router.back();
@@ -17,6 +22,17 @@ export default function RegisterDonePage() {
     const handleGoToInput = () => {
         router.push('/edit');
     };
+
+    //이거 아직 S3에 배포 안되어서 더미로 넣음
+    const getResolvedImageUrl = (img?: string) => {
+        if (!img || img === 'null') return '/images/gray-circle.png';
+
+        if (img.startsWith('http')) return img;
+
+        return `https://your-temp-domain.com/${img}`;
+    };
+    //여기까지 더미 
+
 
     return (
         <Container>
@@ -27,12 +43,23 @@ export default function RegisterDonePage() {
             </TopBar>
 
             <Content>
+                {img && (
+                    <Image
+                        // src={img}
+                        src={getResolvedImageUrl(img)} //여기 더미 넣음
+                        alt={name || '서비스 로고'}
+                        width={80}
+                        height={80}
+                        style={{ borderRadius: '50%' }}
+                    />
+                )}
                 <Message>
-                    <span>“넷플릭스”를 구독하고 계시는군요!</span>
+                    <span>
+                        “{name}”{getParticle(name || '', ['을', '를'])} 구독하고 계시는군요!
+                    </span>
                     <br />
                     구독 정보를 입력하러 가볼까요?
                 </Message>
-
                 <ConfirmButton onClick={handleGoToInput}>
                     입력하러 가기
                 </ConfirmButton>

--- a/src/utils/postposition.ts
+++ b/src/utils/postposition.ts
@@ -1,0 +1,8 @@
+// utils/postposition.ts
+export const getParticle = (word: string, particle: [string, string]) => {
+    if (!word) return particle[0];
+    const lastChar = word[word.length - 1];
+    const code = lastChar.charCodeAt(0) - 44032;
+    const hasFinalConsonant = code % 28 !== 0;
+    return hasFinalConsonant ? particle[0] : particle[1];
+};


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: register, register/done 페이지 검색 api 연동(#24 )
-->

## 📌 관련 이슈

- closes: #24

## ✨ PR 세부 내용

-아직 이미지를 백엔드에서 S3에 배포를 안했기 때문에
register/done 페이지에서 이미지가 더미데이터로 뜨도록 했습니다. (피그마 상으로는 없긴 합니다.

- 을/를을 상황에 따라 자동으로 지정되게 하기 위해서
utils 폴더에 postposition.ts를 추가하고
register/done에서 import하여 사용하였습니다.
 

## ⌛ 소요 시간

20분